### PR TITLE
Add Resources Page Schema and Seed Data

### DIFF
--- a/server/prisma/schema/community.prisma
+++ b/server/prisma/schema/community.prisma
@@ -1,32 +1,39 @@
 model Update {
-  id          String    @id @default(uuid())
-  date        DateTime  @db.Date
-  title       String
-  tag         String
-  note        String?
-  imageUrl    String?   @map("image_url")
-  isPublished Boolean   @default(true) @map("is_published")
-  createdAt   DateTime  @default(now()) @map("created_at")
-  createdBy   String?   @map("created_by")
-  updatedAt   DateTime? @updatedAt @map("updated_at")
-  updatedBy   String?   @map("updated_by")
+  id               String         @id @default(uuid())
+  date             DateTime       @db.Date
+  title            String
+  category         UpdateCategory
+  note             String?        @db.Text
+  imageUrl         String?        @map("image_url")
+  imageStoragePath String?        @map("image_storage_path")
+  isPublished      Boolean        @default(true) @map("is_published")
+  isFeatured       Boolean        @default(false) @map("is_featured")
+  publishedAt      DateTime?      @map("published_at")
+  slug             String?        @unique
+  createdAt        DateTime       @default(now()) @map("created_at")
+  createdBy        String?        @map("created_by")
+  updatedAt        DateTime?      @updatedAt @map("updated_at")
+  updatedBy        String?        @map("updated_by")
 
   createdByUser User?            @relation("UpdateCreatedBy", fields: [createdBy], references: [id])
   updatedByUser User?            @relation("UpdateUpdatedBy", fields: [updatedBy], references: [id])
   reactions     UpdateReaction[]
 
   @@index([date])
-  @@index([tag])
+  @@index([category])
   @@index([isPublished])
+  @@index([isFeatured])
+  @@index([publishedAt])
   @@map("updates")
 }
 
 model UpdateReaction {
-  id        String   @id @default(uuid())
-  updateId  String   @map("update_id")
-  userId    String   @map("user_id")
-  emojiType String   @map("emoji_type")
-  createdAt DateTime @default(now()) @map("created_at")
+  id        String    @id @default(uuid())
+  updateId  String    @map("update_id")
+  userId    String    @map("user_id")
+  emojiType String    @map("emoji_type")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime? @updatedAt @map("updated_at")
 
   update Update @relation(fields: [updateId], references: [id])
   user   User   @relation(fields: [userId], references: [id])
@@ -38,25 +45,38 @@ model UpdateReaction {
 }
 
 model Suggestion {
-  id          String    @id @default(uuid())
-  title       String
-  description String?
-  status      String    @default("open_vote")
-  voteCount   Int       @default(0) @map("vote_count")
-  isVisible   Boolean   @default(true) @map("is_visible")
-  createdAt   DateTime  @default(now()) @map("created_at")
-  createdBy   String?   @map("created_by")
-  updatedAt   DateTime? @updatedAt @map("updated_at")
-  updatedBy   String?   @map("updated_by")
+  id              String              @id @default(uuid())
+  title           String
+  description     String?             @db.Text
+  category        SuggestionCategory?
+  status          SuggestionStatus    @default(OPEN_VOTE)
+  priority        Int?
+  voteCount       Int                 @default(0) @map("vote_count")
+  isVisible       Boolean             @default(true) @map("is_visible")
+  reviewedBy      String?             @map("reviewed_by")
+  reviewedAt      DateTime?           @map("reviewed_at")
+  implementedAt   DateTime?           @map("implemented_at")
+  closedAt        DateTime?           @map("closed_at")
+  closedReason    String?             @map("closed_reason")
+  relatedIssueUrl String?             @map("related_issue_url")
+  createdAt       DateTime            @default(now()) @map("created_at")
+  createdBy       String?             @map("created_by")
+  updatedAt       DateTime?           @updatedAt @map("updated_at")
+  updatedBy       String?             @map("updated_by")
 
   createdByUser User?            @relation("SuggestionCreatedBy", fields: [createdBy], references: [id])
   updatedByUser User?            @relation("SuggestionUpdatedBy", fields: [updatedBy], references: [id])
+  reviewer      User?            @relation("SuggestionReviewer", fields: [reviewedBy], references: [id])
   votes         SuggestionVote[]
 
+  @@index([category])
   @@index([status])
+  @@index([priority])
   @@index([voteCount])
   @@index([isVisible])
   @@index([createdAt])
+  @@index([reviewedAt])
+  @@index([implementedAt])
   @@map("suggestions")
 }
 
@@ -78,24 +98,31 @@ model SuggestionVote {
 }
 
 model TeamMember {
-  id           String    @id @default(uuid())
-  userId       String    @unique @map("user_id")
-  displayName  String    @map("display_name")
-  role         String
-  bio          String?
-  avatarUrl    String?   @map("avatar_url")
-  displayOrder Int?      @map("display_order")
-  isActive     Boolean   @default(true) @map("is_active")
-  createdAt    DateTime  @default(now()) @map("created_at")
-  createdBy    String?   @map("created_by")
-  updatedAt    DateTime? @updatedAt @map("updated_at")
-  updatedBy    String?   @map("updated_by")
+  id               String    @id @default(uuid())
+  userId           String    @unique @map("user_id")
+  displayName      String    @map("display_name")
+  role             String
+  bio              String?   @db.Text
+  avatarUrl        String?   @map("avatar_url")
+  imageStoragePath String?   @map("image_storage_path")
+  sortOrder        Int?      @map("sort_order")
+  startDate        DateTime? @map("start_date") @db.Date
+  endDate          DateTime? @map("end_date") @db.Date
+  socialLinks      Json?     @map("social_links")
+  expertise        Json?
+  isActive         Boolean   @default(true) @map("is_active")
+  createdAt        DateTime  @default(now()) @map("created_at")
+  createdBy        String?   @map("created_by")
+  updatedAt        DateTime? @updatedAt @map("updated_at")
+  updatedBy        String?   @map("updated_by")
 
   user          User  @relation("TeamMemberUser", fields: [userId], references: [id])
   createdByUser User? @relation("TeamMemberCreatedBy", fields: [createdBy], references: [id])
   updatedByUser User? @relation("TeamMemberUpdatedBy", fields: [updatedBy], references: [id])
 
   @@index([isActive])
-  @@index([displayOrder])
+  @@index([sortOrder])
+  @@index([startDate])
+  @@index([endDate])
   @@map("team_members")
 }

--- a/server/prisma/schema/enums.prisma
+++ b/server/prisma/schema/enums.prisma
@@ -47,3 +47,11 @@ enum AdversarialType {
   CONTEXT_CONFUSION  @map("context_confusion")
   PREMISE_DISTORTION @map("premise_distortion")
 }
+
+enum BenchmarkType {
+  MULTIPLE_CHOICE @map("multiple_choice")
+  OPEN_ENDED      @map("open_ended")
+  CONVERSATION    @map("conversation")
+  MIXED           @map("mixed")
+  OTHER           @map("other")
+}

--- a/server/prisma/schema/enums.prisma
+++ b/server/prisma/schema/enums.prisma
@@ -55,3 +55,32 @@ enum BenchmarkType {
   MIXED           @map("mixed")
   OTHER           @map("other")
 }
+
+enum UpdateCategory {
+  FEATURE      @map("feature")
+  BUG_FIX      @map("bug_fix")
+  IMPROVEMENT  @map("improvement")
+  ANNOUNCEMENT @map("announcement")
+  RESEARCH     @map("research")
+  COMMUNITY    @map("community")
+}
+
+enum SuggestionStatus {
+  OPEN_VOTE    @map("open_vote")
+  UNDER_REVIEW @map("under_review")
+  PLANNED      @map("planned")
+  IN_PROGRESS  @map("in_progress")
+  COMPLETED    @map("completed")
+  DECLINED     @map("declined")
+  DUPLICATE    @map("duplicate")
+}
+
+enum SuggestionCategory {
+  FEATURE       @map("feature")
+  BENCHMARK     @map("benchmark")
+  MODEL         @map("model")
+  UI_UX         @map("ui_ux")
+  DOCUMENTATION @map("documentation")
+  BUG           @map("bug")
+  OTHER         @map("other")
+}

--- a/server/prisma/schema/resources.prisma
+++ b/server/prisma/schema/resources.prisma
@@ -1,0 +1,180 @@
+// ==================== RESOURCE MODELS ====================
+// External resources for the Resources page: benchmarks, articles, and papers
+
+model ResourceBenchmark {
+  id               String        @id @default(uuid())
+  name             String
+  description      String?       @db.Text
+  benchmarkType    BenchmarkType @map("benchmark_type")
+  format           String?       @db.Text
+  imageUrl         String?       @map("image_url")
+  imageStoragePath String?       @map("image_storage_path")
+  links            Json?
+  firstReleased    DateTime?     @map("first_released") @db.Date
+  organization     String?
+  language         String?       @default("en")
+  questionCount    Int?          @map("question_count")
+  isActive         Boolean       @default(true) @map("is_active")
+  isFeatured       Boolean       @default(false) @map("is_featured")
+  metadata         Json?
+  createdAt        DateTime      @default(now()) @map("created_at")
+  createdBy        String?       @map("created_by")
+  updatedAt        DateTime?     @updatedAt @map("updated_at")
+  updatedBy        String?       @map("updated_by")
+
+  createdByUser User?                        @relation("ResourceBenchmarkCreatedBy", fields: [createdBy], references: [id])
+  updatedByUser User?                        @relation("ResourceBenchmarkUpdatedBy", fields: [updatedBy], references: [id])
+  tags          ResourceBenchmarkTagLink[]
+
+  @@index([benchmarkType])
+  @@index([isActive])
+  @@index([isFeatured])
+  @@index([firstReleased])
+  @@map("resource_benchmarks")
+}
+
+model ResourceArticle {
+  id               String    @id @default(uuid())
+  title            String
+  author           String?
+  publicationDate  DateTime? @map("publication_date") @db.Date
+  publisher        String?
+  url              String
+  summary          String?   @db.Text
+  imageUrl         String?   @map("image_url")
+  imageStoragePath String?   @map("image_storage_path")
+  articleType      String?   @map("article_type")
+  language         String?   @default("en")
+  readTimeMinutes  Int?      @map("read_time_minutes")
+  isPublished      Boolean   @default(false) @map("is_published")
+  isFeatured       Boolean   @default(false) @map("is_featured")
+  publishedAt      DateTime? @map("published_at")
+  metadata         Json?
+  createdAt        DateTime  @default(now()) @map("created_at")
+  createdBy        String?   @map("created_by")
+  updatedAt        DateTime? @updatedAt @map("updated_at")
+  updatedBy        String?   @map("updated_by")
+
+  createdByUser User?                    @relation("ResourceArticleCreatedBy", fields: [createdBy], references: [id])
+  updatedByUser User?                    @relation("ResourceArticleUpdatedBy", fields: [updatedBy], references: [id])
+  tags          ResourceArticleTagLink[]
+
+  @@index([publicationDate])
+  @@index([publisher])
+  @@index([articleType])
+  @@index([isPublished])
+  @@index([isFeatured])
+  @@index([publishedAt])
+  @@map("resource_articles")
+}
+
+model ResourcePaper {
+  id               String    @id @default(uuid())
+  title            String
+  authors          Json
+  publicationDate  DateTime? @map("publication_date") @db.Date
+  publication      String?
+  venue            String?
+  arxivId          String?   @map("arxiv_id")
+  doi              String?
+  url              String?
+  pdfUrl           String?   @map("pdf_url")
+  abstract         String?   @db.Text
+  imageUrl         String?   @map("image_url")
+  imageStoragePath String?   @map("image_storage_path")
+  citationCount    Int?      @map("citation_count")
+  paperType        String?   @map("paper_type")
+  isPreprint       Boolean   @default(false) @map("is_preprint")
+  isPeerReviewed   Boolean   @default(false) @map("is_peer_reviewed")
+  isPublished      Boolean   @default(false) @map("is_published")
+  isFeatured       Boolean   @default(false) @map("is_featured")
+  citation         Json?
+  metadata         Json?
+  createdAt        DateTime  @default(now()) @map("created_at")
+  createdBy        String?   @map("created_by")
+  updatedAt        DateTime? @updatedAt @map("updated_at")
+  updatedBy        String?   @map("updated_by")
+
+  createdByUser User?                  @relation("ResourcePaperCreatedBy", fields: [createdBy], references: [id])
+  updatedByUser User?                  @relation("ResourcePaperUpdatedBy", fields: [updatedBy], references: [id])
+  tags          ResourcePaperTagLink[]
+
+  @@index([arxivId])
+  @@index([doi])
+  @@index([publicationDate])
+  @@index([paperType])
+  @@index([isPreprint])
+  @@index([isPeerReviewed])
+  @@index([isPublished])
+  @@index([isFeatured])
+  @@map("resource_papers")
+}
+
+model ResourceTag {
+  id          String    @id @default(uuid())
+  name        String    @unique
+  slug        String    @unique
+  description String?
+  category    String?
+  color       String?
+  icon        String?
+  sortOrder   Int?      @map("sort_order")
+  isActive    Boolean   @default(true) @map("is_active")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  createdBy   String?   @map("created_by")
+  updatedAt   DateTime? @updatedAt @map("updated_at")
+  updatedBy   String?   @map("updated_by")
+
+  createdByUser User?                      @relation("ResourceTagCreatedBy", fields: [createdBy], references: [id])
+  updatedByUser User?                      @relation("ResourceTagUpdatedBy", fields: [updatedBy], references: [id])
+  benchmarks    ResourceBenchmarkTagLink[]
+  articles      ResourceArticleTagLink[]
+  papers        ResourcePaperTagLink[]
+
+  @@index([category])
+  @@index([isActive])
+  @@index([sortOrder])
+  @@map("resource_tags")
+}
+
+model ResourceBenchmarkTagLink {
+  id          String @id @default(uuid())
+  benchmarkId String @map("benchmark_id")
+  tagId       String @map("tag_id")
+
+  benchmark ResourceBenchmark @relation(fields: [benchmarkId], references: [id], onDelete: Cascade)
+  tag       ResourceTag       @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([benchmarkId, tagId])
+  @@index([benchmarkId])
+  @@index([tagId])
+  @@map("resource_benchmark_tag_link")
+}
+
+model ResourceArticleTagLink {
+  id        String @id @default(uuid())
+  articleId String @map("article_id")
+  tagId     String @map("tag_id")
+
+  article ResourceArticle @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  tag     ResourceTag     @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([articleId, tagId])
+  @@index([articleId])
+  @@index([tagId])
+  @@map("resource_article_tag_link")
+}
+
+model ResourcePaperTagLink {
+  id      String @id @default(uuid())
+  paperId String @map("paper_id")
+  tagId   String @map("tag_id")
+
+  paper ResourcePaper @relation(fields: [paperId], references: [id], onDelete: Cascade)
+  tag   ResourceTag   @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@unique([paperId, tagId])
+  @@index([paperId])
+  @@index([tagId])
+  @@map("resource_paper_tag_link")
+}

--- a/server/prisma/schema/users.prisma
+++ b/server/prisma/schema/users.prisma
@@ -91,6 +91,16 @@ model User {
   systemConfigsCreated    SystemConfig[]   @relation("SystemConfigCreatedBy")
   systemConfigsUpdated    SystemConfig[]   @relation("SystemConfigUpdatedBy")
 
+  // Resources
+  resourceBenchmarksCreated ResourceBenchmark[] @relation("ResourceBenchmarkCreatedBy")
+  resourceBenchmarksUpdated ResourceBenchmark[] @relation("ResourceBenchmarkUpdatedBy")
+  resourceArticlesCreated   ResourceArticle[]   @relation("ResourceArticleCreatedBy")
+  resourceArticlesUpdated   ResourceArticle[]   @relation("ResourceArticleUpdatedBy")
+  resourcePapersCreated     ResourcePaper[]     @relation("ResourcePaperCreatedBy")
+  resourcePapersUpdated     ResourcePaper[]     @relation("ResourcePaperUpdatedBy")
+  resourceTagsCreated       ResourceTag[]       @relation("ResourceTagCreatedBy")
+  resourceTagsUpdated       ResourceTag[]       @relation("ResourceTagUpdatedBy")
+
   @@index([email])
   @@index([username])
   @@index([role])

--- a/server/prisma/schema/users.prisma
+++ b/server/prisma/schema/users.prisma
@@ -65,15 +65,16 @@ model User {
   tagsUpdated            BenchmarkTag[]                @relation("BenchmarkTagUpdatedBy")
 
   // Community
-  updatesCreated     Update[]         @relation("UpdateCreatedBy")
-  updatesUpdated     Update[]         @relation("UpdateUpdatedBy")
-  updateReactions    UpdateReaction[]
-  suggestionsCreated Suggestion[]     @relation("SuggestionCreatedBy")
-  suggestionsUpdated Suggestion[]     @relation("SuggestionUpdatedBy")
-  suggestionVotes    SuggestionVote[]
-  teamMemberProfile  TeamMember?      @relation("TeamMemberUser")
-  teamMembersCreated TeamMember[]     @relation("TeamMemberCreatedBy")
-  teamMembersUpdated TeamMember[]     @relation("TeamMemberUpdatedBy")
+  updatesCreated      Update[]         @relation("UpdateCreatedBy")
+  updatesUpdated      Update[]         @relation("UpdateUpdatedBy")
+  updateReactions     UpdateReaction[]
+  suggestionsCreated  Suggestion[]     @relation("SuggestionCreatedBy")
+  suggestionsUpdated  Suggestion[]     @relation("SuggestionUpdatedBy")
+  suggestionsReviewed Suggestion[]     @relation("SuggestionReviewer")
+  suggestionVotes     SuggestionVote[]
+  teamMemberProfile   TeamMember?      @relation("TeamMemberUser")
+  teamMembersCreated  TeamMember[]     @relation("TeamMemberCreatedBy")
+  teamMembersUpdated  TeamMember[]     @relation("TeamMemberUpdatedBy")
 
   // Auth & Expertise
   sessions             UserSession[]

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -6,8 +6,8 @@ const seedIRIConversationalProfile = require('./seeds/iriConversationalProfile')
 const seedHexacoConversationalProfile = require('./seeds/hexacoConversationalProfile');
 const seedUsers = require('./seeds/users');
 const seedResources = require('./seeds/resources');
+const seedCommunity = require('./seeds/community');
 // const seedBenchmarking = require('./seeds/benchmarking');
-// const seedCommunity = require('./seeds/community');
 // const seedExperiments = require('./seeds/experiments');
 // const seedHyperparameters = require('./seeds/hyperparameters');
 // const seedResults = require('./seeds/results');
@@ -42,13 +42,13 @@ async function main() {
 
   await seedResources(prisma);
 
+  await seedCommunity(prisma, {
+    researcherUser: users.researcherUser,
+    regularUser: users.regularUser,
+  });
+
   // const benchmarking = await seedBenchmarking(prisma, {
   //   researcherUser: users.researcherUser,
-  // });
-
-  // await seedCommunity(prisma, {
-  //   researcherUser: users.researcherUser,
-  //   regularUser: users.regularUser,
   // });
 
   // const experimentContexts = await seedExperiments(prisma, {
@@ -80,7 +80,7 @@ async function main() {
   //   benchmarking,
   // });
 
-  console.log('Database seed completed successfully (core models + tech profiles + resources).');
+  console.log('Database seed completed successfully (core models + tech profiles + resources + community).');
 }
 
 main()

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -5,6 +5,7 @@ const seedTechProfiles = require('./seeds/techProfiles');
 const seedIRIConversationalProfile = require('./seeds/iriConversationalProfile');
 const seedHexacoConversationalProfile = require('./seeds/hexacoConversationalProfile');
 const seedUsers = require('./seeds/users');
+const seedResources = require('./seeds/resources');
 // const seedBenchmarking = require('./seeds/benchmarking');
 // const seedCommunity = require('./seeds/community');
 // const seedExperiments = require('./seeds/experiments');
@@ -38,6 +39,8 @@ async function main() {
     models: models.models,
     modelVersions: models.modelVersions,
   });
+
+  await seedResources(prisma);
 
   // const benchmarking = await seedBenchmarking(prisma, {
   //   researcherUser: users.researcherUser,
@@ -77,7 +80,7 @@ async function main() {
   //   benchmarking,
   // });
 
-  console.log('Database seed completed successfully (core models + tech profiles).');
+  console.log('Database seed completed successfully (core models + tech profiles + resources).');
 }
 
 main()

--- a/server/prisma/seeds/community.js
+++ b/server/prisma/seeds/community.js
@@ -1,11 +1,15 @@
 module.exports = async function seedCommunity(prisma, { researcherUser, regularUser }) {
+  // Updates with new schema
   await prisma.update.create({
     data: {
       date: new Date('2024-09-01'),
       title: 'Platform Launch',
-      tag: 'new features',
-      note: 'Welcome to MindBench.ai! Our platform for benchmarking AI models is now live.',
+      category: 'ANNOUNCEMENT',
+      note: 'Welcome to MindBench.ai! Our platform for benchmarking AI models is now live. We\'re excited to bring rigorous, expert-driven evaluation to mental health AI systems.',
       isPublished: true,
+      isFeatured: true,
+      publishedAt: new Date('2024-09-01T09:00:00Z'),
+      slug: 'platform-launch',
       createdBy: researcherUser.id,
     },
   });
@@ -14,18 +18,52 @@ module.exports = async function seedCommunity(prisma, { researcherUser, regularU
     data: {
       date: new Date('2024-09-15'),
       title: 'Added GPT-4o and Claude Opus',
-      tag: 'updates',
-      note: 'New models have been added to our benchmarking suite.',
+      category: 'FEATURE',
+      note: 'New models have been added to our benchmarking suite. GPT-4o and Claude Opus are now available for evaluation across all benchmark scales.',
       isPublished: true,
+      isFeatured: false,
+      publishedAt: new Date('2024-09-15T14:30:00Z'),
+      slug: 'new-models-gpt4o-claude-opus',
       createdBy: researcherUser.id,
     },
   });
 
+  await prisma.update.create({
+    data: {
+      date: new Date('2024-10-12'),
+      title: 'Improved Leaderboard Performance',
+      category: 'IMPROVEMENT',
+      note: 'Optimized database queries for faster leaderboard loading. Average page load time reduced by 60%.',
+      isPublished: true,
+      isFeatured: false,
+      publishedAt: new Date('2024-10-12T11:00:00Z'),
+      slug: 'leaderboard-performance-improvements',
+      createdBy: researcherUser.id,
+    },
+  });
+
+  await prisma.update.create({
+    data: {
+      date: new Date('2024-11-05'),
+      title: 'Fixed Rating Submission Bug',
+      category: 'BUG_FIX',
+      note: 'Resolved an issue where expert ratings were not being saved correctly on mobile devices.',
+      isPublished: true,
+      isFeatured: false,
+      publishedAt: new Date('2024-11-05T16:45:00Z'),
+      slug: 'rating-submission-bug-fix',
+      createdBy: researcherUser.id,
+    },
+  });
+
+  // Suggestions with new schema
   await prisma.suggestion.create({
     data: {
       title: 'Add DeepSeek models',
-      description: 'Please add DeepSeek-V3 and V2.5 to the platform',
-      status: 'open_vote',
+      description: 'Please add DeepSeek-V3 and DeepSeek-V2.5 to the platform. These models have shown impressive performance on reasoning tasks and would be valuable additions to the mental health benchmark suite.',
+      category: 'MODEL',
+      status: 'OPEN_VOTE',
+      priority: 3,
       voteCount: 15,
       isVisible: true,
       createdBy: regularUser.id,
@@ -35,10 +73,88 @@ module.exports = async function seedCommunity(prisma, { researcherUser, regularU
   await prisma.suggestion.create({
     data: {
       title: 'Dark mode',
-      description: 'Add a dark mode toggle for better viewing experience',
-      status: 'planned',
+      description: 'Add a dark mode toggle for better viewing experience, especially during late-night research sessions.',
+      category: 'UI_UX',
+      status: 'PLANNED',
+      priority: 2,
       voteCount: 42,
       isVisible: true,
+      reviewedBy: researcherUser.id,
+      reviewedAt: new Date('2024-11-10T10:00:00Z'),
+      createdBy: regularUser.id,
+    },
+  });
+
+  await prisma.suggestion.create({
+    data: {
+      title: 'Add CounselBench to resources page',
+      description: 'Include CounselBench in the external benchmarks section of the resources page with links to the paper and GitHub repo.',
+      category: 'FEATURE',
+      status: 'COMPLETED',
+      priority: 4,
+      voteCount: 28,
+      isVisible: true,
+      reviewedBy: researcherUser.id,
+      reviewedAt: new Date('2024-10-15T14:00:00Z'),
+      implementedAt: new Date('2024-10-20T16:30:00Z'),
+      relatedIssueUrl: 'https://github.com/MattMatt27/MindBenchAI/issues/123',
+      createdBy: regularUser.id,
+    },
+  });
+
+  await prisma.suggestion.create({
+    data: {
+      title: 'Export benchmark results to CSV',
+      description: 'Allow users to export their benchmark results and comparisons to CSV format for further analysis.',
+      category: 'FEATURE',
+      status: 'UNDER_REVIEW',
+      priority: 3,
+      voteCount: 35,
+      isVisible: true,
+      reviewedBy: researcherUser.id,
+      reviewedAt: new Date('2024-11-12T09:30:00Z'),
+      createdBy: regularUser.id,
+    },
+  });
+
+  await prisma.suggestion.create({
+    data: {
+      title: 'Add support for GPT-3.5',
+      description: 'Include GPT-3.5 Turbo in the available models for benchmarking.',
+      category: 'MODEL',
+      status: 'DECLINED',
+      priority: 1,
+      voteCount: 8,
+      isVisible: true,
+      reviewedBy: researcherUser.id,
+      reviewedAt: new Date('2024-09-20T11:00:00Z'),
+      closedAt: new Date('2024-09-20T11:15:00Z'),
+      closedReason: 'GPT-3.5 does not meet our minimum performance thresholds for mental health applications. We recommend GPT-4 or newer models.',
+      createdBy: regularUser.id,
+    },
+  });
+
+  // Team member example with new fields
+  await prisma.teamMember.create({
+    data: {
+      userId: researcherUser.id,
+      displayName: 'Dr. Research Lead',
+      role: 'Principal Investigator',
+      bio: 'Clinical psychologist and AI researcher specializing in the evaluation of large language models for mental health applications. Focus on ensuring scientific rigor and clinical validity in AI benchmarking.',
+      sortOrder: 1,
+      startDate: new Date('2023-06-01'),
+      socialLinks: {
+        github: 'https://github.com/researcher',
+        linkedin: 'https://linkedin.com/in/researcher',
+        twitter: 'https://twitter.com/researcher'
+      },
+      expertise: [
+        'Clinical Psychology',
+        'AI Safety',
+        'Mental Health Evaluation',
+        'Research Design'
+      ],
+      isActive: true,
       createdBy: researcherUser.id,
     },
   });

--- a/server/prisma/seeds/resourceArticleTagLinks.js
+++ b/server/prisma/seeds/resourceArticleTagLinks.js
@@ -1,0 +1,33 @@
+/**
+ * Seed data for ResourceArticleTagLink table
+ * Links articles to their relevant tags
+ */
+
+const resourceArticleTagLinks = [
+  // "AI Chatbots for Mental Health: Promise and Peril"
+  { articleId: '770e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { articleId: '770e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440401' }, // Conversational AI
+  { articleId: '770e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440403' }, // Safety & Risk
+  { articleId: '770e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440404' }, // Empathy & Understanding
+
+  // "Stanford Researchers Develop New Benchmark for Evaluating AI Therapists"
+  { articleId: '770e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { articleId: '770e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { articleId: '770e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { articleId: '770e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440403' }, // Safety & Risk
+  { articleId: '770e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440404' }, // Empathy & Understanding
+
+  // "Why Mental Health Benchmarks Need More Than Accuracy"
+  { articleId: '770e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { articleId: '770e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { articleId: '770e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440101' }, // Clinical Psychology
+  { articleId: '770e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440404' }, // Empathy & Understanding
+
+  // "The Role of Large Language Models in Digital Mental Health: An Interview"
+  { articleId: '770e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { articleId: '770e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { articleId: '770e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { articleId: '770e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440401' }  // Conversational AI
+];
+
+module.exports = { resourceArticleTagLinks };

--- a/server/prisma/seeds/resourceArticles.js
+++ b/server/prisma/seeds/resourceArticles.js
@@ -1,0 +1,95 @@
+/**
+ * Seed data for ResourceArticle table
+ * News articles and blog posts about mental health AI
+ */
+
+const resourceArticles = [
+  {
+    id: '770e8400-e29b-41d4-a716-446655440100',
+    title: 'AI Chatbots for Mental Health: Promise and Peril',
+    author: 'Dr. Sarah Chen',
+    publicationDate: new Date('2024-11-15'),
+    publisher: 'Nature',
+    url: 'https://www.nature.com/articles/example-ai-mental-health',
+    summary: 'An in-depth look at the growing use of AI-powered chatbots in mental health care, examining both the potential benefits for accessibility and the ethical concerns around safety, privacy, and the quality of therapeutic relationships. Reviews recent benchmarks and evaluation frameworks.',
+    imageUrl: null,
+    imageStoragePath: null,
+    articleType: 'research_summary',
+    language: 'en',
+    readTimeMinutes: 12,
+    isPublished: true,
+    isFeatured: true,
+    publishedAt: new Date('2024-11-15'),
+    metadata: {
+      keywords: ['AI chatbots', 'mental health', 'ethics', 'accessibility'],
+      doi: '10.1038/example'
+    }
+  },
+
+  {
+    id: '770e8400-e29b-41d4-a716-446655440101',
+    title: 'Stanford Researchers Develop New Benchmark for Evaluating AI Therapists',
+    author: 'Michael Rodriguez',
+    publicationDate: new Date('2025-03-20'),
+    publisher: 'MIT Technology Review',
+    url: 'https://www.technologyreview.com/example-ai-therapist-benchmark',
+    summary: 'Stanford researchers have released a new benchmark dataset featuring real patient questions and expert therapist evaluations. The benchmark aims to address gaps in current LLM evaluation for mental health applications, with particular focus on safety and empathy metrics.',
+    imageUrl: null,
+    imageStoragePath: null,
+    articleType: 'news',
+    language: 'en',
+    readTimeMinutes: 7,
+    isPublished: true,
+    isFeatured: true,
+    publishedAt: new Date('2025-03-20'),
+    metadata: {
+      keywords: ['benchmark', 'Stanford', 'evaluation', 'LLM'],
+      institution: 'Stanford University'
+    }
+  },
+
+  {
+    id: '770e8400-e29b-41d4-a716-446655440102',
+    title: 'Why Mental Health Benchmarks Need More Than Accuracy',
+    author: 'Dr. James Park',
+    publicationDate: new Date('2024-09-10'),
+    publisher: 'The Gradient',
+    url: 'https://thegradient.pub/example-mental-health-metrics',
+    summary: 'A critical analysis of current mental health AI benchmarks and their limitations. Argues that accuracy-focused metrics miss crucial dimensions like empathy, cultural sensitivity, and harm prevention. Proposes a multi-dimensional evaluation framework drawing from clinical psychology.',
+    imageUrl: null,
+    imageStoragePath: null,
+    articleType: 'opinion',
+    language: 'en',
+    readTimeMinutes: 10,
+    isPublished: true,
+    isFeatured: false,
+    publishedAt: new Date('2024-09-10'),
+    metadata: {
+      keywords: ['evaluation metrics', 'empathy', 'clinical psychology', 'bias']
+    }
+  },
+
+  {
+    id: '770e8400-e29b-41d4-a716-446655440103',
+    title: 'The Role of Large Language Models in Digital Mental Health: An Interview with Leading Researchers',
+    author: 'Emma Thompson',
+    publicationDate: new Date('2024-12-05'),
+    publisher: 'Psychology Today',
+    url: 'https://www.psychologytoday.com/example-llm-interview',
+    summary: 'Interviews with researchers from Penn, Georgetown, and CUHK on the current state and future of LLMs in mental health. Discusses recent benchmarks including CounselBench and MentalChat16K, clinical validation challenges, and the importance of human oversight.',
+    imageUrl: null,
+    imageStoragePath: null,
+    articleType: 'interview',
+    language: 'en',
+    readTimeMinutes: 15,
+    isPublished: true,
+    isFeatured: true,
+    publishedAt: new Date('2024-12-05'),
+    metadata: {
+      keywords: ['LLM', 'interviews', 'experts', 'digital health'],
+      interviewees: ['Penn Shen Lab', 'Georgetown IR Lab', 'CUHK ARISE']
+    }
+  }
+];
+
+module.exports = { resourceArticles };

--- a/server/prisma/seeds/resourceBenchmarkTagLinks.js
+++ b/server/prisma/seeds/resourceBenchmarkTagLinks.js
@@ -1,0 +1,93 @@
+/**
+ * Seed data for ResourceBenchmarkTagLink table
+ * Links benchmarks to their relevant tags
+ */
+
+const resourceBenchmarkTagLinks = [
+  // CounselBench tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440302' }, // Expert Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440400' }, // Question Answering
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440403' }, // Safety & Risk
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440404' }, // Empathy & Understanding
+
+  // DAIC-WOZ tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440101' }, // Clinical Psychology
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440200' }, // Depression
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440201' }, // Anxiety
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440202' }, // PTSD
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440301' }, // Clinical Assessment
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440303' }, // Multimodal
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440402' }, // Detection & Screening
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440500' }, // Clinical Trials
+
+  // MentalChat16K tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440200' }, // Depression
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440201' }, // Anxiety
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440401' }, // Conversational AI
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440400' }, // Question Answering
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440500' }, // Clinical Trials
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440501' }, // Synthetic Data
+
+  // SMHD tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440200' }, // Depression
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440201' }, // Anxiety
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440202' }, // PTSD
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440204' }, // OCD
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440205' }, // Bipolar Disorder
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440304' }, // Social Media Analysis
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440402' }, // Detection & Screening
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440103', tagId: '660e8400-e29b-41d4-a716-446655440502' }, // Reddit
+
+  // PsychoBench (Counseling Competence) tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440104', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440104', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440104', tagId: '660e8400-e29b-41d4-a716-446655440101' }, // Clinical Psychology
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440104', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440104', tagId: '660e8400-e29b-41d4-a716-446655440504' }, // Standardized Exams
+
+  // PsychoBench (Psychological Portrayal) tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440105', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440105', tagId: '660e8400-e29b-41d4-a716-446655440101' }, // Clinical Psychology
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440105', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440105', tagId: '660e8400-e29b-41d4-a716-446655440301' }, // Clinical Assessment
+
+  // MHQA tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440201' }, // Anxiety
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440200' }, // Depression
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440203' }, // Trauma
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440204' }, // OCD
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440400' }, // Question Answering
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440106', tagId: '660e8400-e29b-41d4-a716-446655440503' }, // PubMed
+
+  // MedQA tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440107', tagId: '660e8400-e29b-41d4-a716-446655440104' }, // General Medicine
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440107', tagId: '660e8400-e29b-41d4-a716-446655440102' }, // Psychiatry
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440107', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440107', tagId: '660e8400-e29b-41d4-a716-446655440504' }, // Standardized Exams
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440107', tagId: '660e8400-e29b-41d4-a716-446655440400' }, // Question Answering
+
+  // CounselChat tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440108', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440108', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440108', tagId: '660e8400-e29b-41d4-a716-446655440400' }, // Question Answering
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440108', tagId: '660e8400-e29b-41d4-a716-446655440302' }, // Expert Evaluation
+
+  // MMLU tags
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440109', tagId: '660e8400-e29b-41d4-a716-446655440104' }, // General Medicine
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440109', tagId: '660e8400-e29b-41d4-a716-446655440101' }, // Clinical Psychology
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440109', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440109', tagId: '660e8400-e29b-41d4-a716-446655440504' }, // Standardized Exams
+  { benchmarkId: '550e8400-e29b-41d4-a716-446655440109', tagId: '660e8400-e29b-41d4-a716-446655440400' }  // Question Answering
+];
+
+module.exports = { resourceBenchmarkTagLinks };

--- a/server/prisma/seeds/resourceBenchmarks.js
+++ b/server/prisma/seeds/resourceBenchmarks.js
@@ -1,0 +1,297 @@
+/**
+ * Seed data for ResourceBenchmark table
+ * External mental health and medical benchmarks
+ */
+
+const resourceBenchmarks = [
+  {
+    id: '550e8400-e29b-41d4-a716-446655440100',
+    name: 'CounselBench',
+    description: 'Developed with 100 mental health professionals to evaluate and stress-test LLMs in realistic help-seeking scenarios. Focuses on single-turn counseling interactions and evaluates models across dimensions including factuality, comprehension, reasoning, possible harm, and bias. The adversarial component tests for systematic failure patterns in mental health QA.',
+    benchmarkType: 'MIXED',
+    format: 'CounselBench-EVAL: 2,000 expert evaluations of LLM responses and human therapist responses to real patient questions from CounselChat. CounselBench-ADV: 120 expert-authored adversarial questions designed to trigger specific model failure modes. Evaluation along 6 clinically grounded dimensions with written rationales and span-level annotations.',
+    imageUrl: null, // TODO: Add when available
+    imageStoragePath: null,
+    links: {
+      github: 'https://github.com/llm-eval-mental-health/CounselBench',
+      paper: 'https://arxiv.org/abs/2506.08584'
+    },
+    firstReleased: new Date('2025-06-01'), // Based on arXiv date
+    organization: 'LLM Eval Mental Health Research Group',
+    language: 'en',
+    questionCount: 2120, // 2000 EVAL + 120 ADV
+    isActive: true,
+    isFeatured: true,
+    metadata: {
+      evaluationDimensions: [
+        'factuality',
+        'comprehension',
+        'reasoning',
+        'possible harm',
+        'bias',
+        'empathy'
+      ],
+      professionalContributors: 100,
+      components: ['CounselBench-EVAL', 'CounselBench-ADV']
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440101',
+    name: 'DAIC-WOZ',
+    description: 'One of the most widely used datasets for depression detection research. Consists of clinical interviews conducted by a human-controlled virtual agent (Ellie) designed to assess indicators of depression, anxiety, and PTSD. Each interview includes multi-modal data (audio, video, text) and clinical annotations. Extended version (E-DAIC) includes larger cohort with additional clinical annotations including PCL-C scores.',
+    benchmarkType: 'CONVERSATION',
+    format: 'Semi-structured clinical interviews with virtual agent. 189 participants in original version, 275 participants in E-DAIC extended version. Multi-modal data including audio, video, and text transcripts. PHQ-8 depression scores and anxiety/PTSD assessments included.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      website: 'https://dcapswoz.ict.usc.edu/'
+    },
+    firstReleased: new Date('2014-01-01'), // Approximate - DAIC-WOZ is from mid-2010s
+    organization: 'USC Institute for Creative Technologies',
+    language: 'en',
+    questionCount: 275, // Number of participants/interviews in E-DAIC
+    isActive: true,
+    isFeatured: true,
+    metadata: {
+      modalities: ['audio', 'video', 'text'],
+      clinicalAssessments: ['PHQ-8', 'PCL-C', 'Anxiety', 'PTSD'],
+      versions: ['DAIC-WOZ (189 participants)', 'E-DAIC (275 participants)'],
+      virtualAgent: 'Ellie',
+      dataUseAgreementRequired: true
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440102',
+    name: 'MentalChat16K',
+    description: 'Benchmark dataset covering depression, anxiety, grief, and other conditions. Used for training and evaluating LLMs for mental health counseling. Includes 7 clinically grounded evaluation metrics. Conversations include both behavioral health coach-caregiver interactions and synthetic therapeutic dialogues.',
+    benchmarkType: 'CONVERSATION',
+    format: '16,113 question-answer pairs consisting of 9,775 synthetic conversations (GPT-3.5 generated) covering 33 mental health topics and 6,338 real anonymized interview transcripts from PISCES clinical trial.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      huggingface: 'https://huggingface.co/datasets/ShenLab/MentalChat16K',
+      github: 'https://github.com/PennShenLab/MentalChat16K',
+      paper: 'https://arxiv.org/abs/2503.13509'
+    },
+    firstReleased: new Date('2025-03-01'), // Based on arXiv date
+    organization: 'Penn Shen Lab',
+    language: 'en',
+    questionCount: 16113,
+    isActive: true,
+    isFeatured: true,
+    metadata: {
+      topics: 33,
+      syntheticConversations: 9775,
+      realTranscripts: 6338,
+      conditions: ['depression', 'anxiety', 'grief'],
+      evaluationMetrics: 7,
+      sourceClinicalTrial: 'PISCES'
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440103',
+    name: 'SMHD (Self-reported Mental Health Diagnoses)',
+    description: 'Large-scale dataset of Reddit posts from users who self-reported mental health diagnoses. Includes matched control users. Much larger text volume than Twitter datasets due to Reddit\'s long-form format. Used extensively for mental health condition classification and language analysis research.',
+    benchmarkType: 'OPEN_ENDED',
+    format: 'Long-form Reddit posts from diagnosed users and matched controls. Covers 9 mental health conditions: Depression, Anxiety, Bipolar Disorder, ADHD, PTSD, OCD, Autism, Schizophrenia, and Eating Disorders.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      website: 'https://ir.cs.georgetown.edu/resources/smhd.html'
+    },
+    firstReleased: new Date('2017-01-01'), // Approximate based on typical SMHD papers
+    organization: 'Georgetown University IR Lab',
+    language: 'en',
+    questionCount: null, // Not applicable - posts rather than questions
+    isActive: true,
+    isFeatured: true,
+    metadata: {
+      platform: 'Reddit',
+      conditions: [
+        'Depression',
+        'Anxiety',
+        'Bipolar Disorder',
+        'ADHD',
+        'PTSD',
+        'OCD',
+        'Autism',
+        'Schizophrenia',
+        'Eating Disorders'
+      ],
+      includesControls: true,
+      dataType: 'long-form social media posts'
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440104',
+    name: 'PsychoBench (Counseling Competence)',
+    description: 'Evaluates LLMs\' capability to perform psychological counseling tasks using exam-style questions that assess factual and applied psychological knowledge. First systematic benchmark for evaluating psychological counseling competence in LLMs. Based on U.S. NCE questions covering various counseling domains.',
+    benchmarkType: 'MULTIPLE_CHOICE',
+    format: 'Multiple-choice questions from U.S. National Counselor Examination (NCE) covering various counseling domains and competencies.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      paper: 'https://arxiv.org/abs/2510.01611'
+    },
+    firstReleased: new Date('2025-10-01'), // Based on arXiv date
+    organization: null, // Not specified in source
+    language: 'en',
+    questionCount: null, // Not specified in excerpt
+    isActive: true,
+    isFeatured: true,
+    metadata: {
+      baseExam: 'U.S. National Counselor Examination (NCE)',
+      focus: 'counseling competence',
+      evaluationType: 'factual and applied psychological knowledge'
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440105',
+    name: 'PsychoBench (Psychological Portrayal)',
+    description: 'Evaluates psychological portrayal of LLMs across 4 categories: personality traits, interpersonal relationships, motivational tests, and emotional abilities. Uses standardized clinical psychology scales to assess whether LLMs can simulate human-like psychological characteristics. Not specifically designed for mental health counseling competency but rather for understanding AI\'s psychological representation.',
+    benchmarkType: 'MULTIPLE_CHOICE',
+    format: 'Multiple-choice questions from 13 standardized psychological scales across 4 psychological categories.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      github: 'https://github.com/CUHK-ARISE/PsychoBench',
+      paper: 'https://arxiv.org/abs/2310.01386'
+    },
+    firstReleased: new Date('2023-10-01'), // Based on arXiv date
+    organization: 'CUHK ARISE Lab',
+    language: 'en',
+    questionCount: null, // Not specified
+    isActive: true,
+    isFeatured: false,
+    metadata: {
+      psychologicalScales: 13,
+      categories: [
+        'personality traits',
+        'interpersonal relationships',
+        'motivational tests',
+        'emotional abilities'
+      ],
+      focus: 'psychological representation in AI'
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440106',
+    name: 'MHQA (Mental Health Question Answering)',
+    description: 'Diverse, knowledge-intensive mental health QA challenge generated from PubMed abstracts. Includes both MHQA-Gold (human validated) and MHQA-B (pseudo-labeled) versions. More targeted and comprehensive than general medical QA datasets for mental health-specific assessment.',
+    benchmarkType: 'MULTIPLE_CHOICE',
+    format: 'Multiple-choice questions across 4 question types, covering topics including Anxiety, Depression, Trauma, and OCD. Generated from PubMed research abstracts.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      paper: 'https://arxiv.org/abs/2502.15418'
+    },
+    firstReleased: new Date('2025-02-01'), // Based on arXiv date
+    organization: null,
+    language: 'en',
+    questionCount: null,
+    isActive: true,
+    isFeatured: true,
+    metadata: {
+      source: 'PubMed abstracts',
+      topics: ['Anxiety', 'Depression', 'Trauma', 'OCD'],
+      versions: ['MHQA-Gold (human validated)', 'MHQA-B (pseudo-labeled)'],
+      questionTypes: 4,
+      focus: 'knowledge-intensive mental health QA'
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440107',
+    name: 'MedQA',
+    description: 'General medical benchmark covering all medical specialties including psychiatry. Questions from USMLE exams covering broad range of medical topics. Estimated ~5-10% of questions relate to mental health/psychiatry topics (psychiatry is one clinical rotation in medical training). Primarily tests medical knowledge and clinical reasoning across medicine.',
+    benchmarkType: 'MULTIPLE_CHOICE',
+    format: 'Multiple-choice questions with 4-5 options. 12,723 questions in English from U.S. Medical Licensing Examination.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      github: 'https://github.com/jind11/MedQA',
+      website: 'https://paperswithcode.com/dataset/medqa-usmle'
+    },
+    firstReleased: new Date('2020-01-01'), // Approximate
+    organization: null,
+    language: 'en',
+    questionCount: 12723,
+    isActive: true,
+    isFeatured: false,
+    metadata: {
+      baseExam: 'USMLE',
+      medicalSpecialties: 'all',
+      mentalHealthPercentage: '5-10%',
+      focus: 'general medical knowledge and clinical reasoning',
+      multilingualVersions: ['Chinese', 'Traditional Chinese']
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440108',
+    name: 'CounselChat',
+    description: 'Questions from clients paired with responses from licensed therapists on online counseling platform. Covers wide range of mental health topics. Used as source for CounselBench evaluation and training data for counseling-focused LLMs.',
+    benchmarkType: 'OPEN_ENDED',
+    format: 'Approximately 3,600 question-answer pairs from licensed therapists responding to client questions on online counseling platform.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      website: 'https://counselchat.com'
+    },
+    firstReleased: null, // Platform date unknown
+    organization: 'CounselChat',
+    language: 'en',
+    questionCount: 3600,
+    isActive: true,
+    isFeatured: false,
+    metadata: {
+      responseProvider: 'licensed therapists',
+      platform: 'online counseling Q&A',
+      usedIn: ['CounselBench', 'various counseling LLM training'],
+      accessNotes: 'Publicly scraped data, referenced in research'
+    }
+  },
+
+  {
+    id: '550e8400-e29b-41d4-a716-446655440109',
+    name: 'MMLU (Clinical & Psychology Subsets)',
+    description: 'General benchmark with mental health content across medical and psychology subsets. Professional Psychology subset directly addresses psychological knowledge. Estimated ~10-15% of medical subset questions relate to mental health/psychiatry, primarily in Professional Psychology and Clinical Knowledge categories.',
+    benchmarkType: 'MULTIPLE_CHOICE',
+    format: '4-option multiple-choice questions across 57 subjects. Medical subsets include: Clinical Knowledge, Professional Medicine, Professional Psychology, College Medicine, Anatomy, Medical Genetics, Nutrition, Virology. Approximately 1,785 questions across medical subsets.',
+    imageUrl: null,
+    imageStoragePath: null,
+    links: {
+      website: 'https://paperswithcode.com/dataset/mmlu',
+      github: 'https://github.com/hendrycks/test'
+    },
+    firstReleased: new Date('2020-01-01'), // MMLU original paper
+    organization: 'UC Berkeley / University of Chicago',
+    language: 'en',
+    questionCount: 1785, // Medical subsets only
+    isActive: true,
+    isFeatured: false,
+    metadata: {
+      totalSubjects: 57,
+      medicalSubsets: [
+        'Clinical Knowledge',
+        'Professional Medicine',
+        'Professional Psychology',
+        'College Medicine',
+        'Anatomy',
+        'Medical Genetics',
+        'Nutrition',
+        'Virology'
+      ],
+      mentalHealthPercentage: '10-15% of medical subsets',
+      fullBenchmarkQuestions: 15908
+    }
+  }
+];
+
+module.exports = { resourceBenchmarks };

--- a/server/prisma/seeds/resourcePaperTagLinks.js
+++ b/server/prisma/seeds/resourcePaperTagLinks.js
@@ -1,0 +1,27 @@
+/**
+ * Seed data for ResourcePaperTagLink table
+ * Links papers to their relevant tags
+ */
+
+const resourcePaperTagLinks = [
+  // "Can AI Help in Therapeutic Conversations?"
+  { paperId: '880e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { paperId: '880e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440103' }, // Counseling
+  { paperId: '880e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440401' }, // Conversational AI
+  { paperId: '880e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440404' }, // Empathy & Understanding
+  { paperId: '880e8400-e29b-41d4-a716-446655440100', tagId: '660e8400-e29b-41d4-a716-446655440403' }, // Safety & Risk
+
+  // "A Framework for Evaluating Empathy"
+  { paperId: '880e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { paperId: '880e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { paperId: '880e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440404' }, // Empathy & Understanding
+  { paperId: '880e8400-e29b-41d4-a716-446655440101', tagId: '660e8400-e29b-41d4-a716-446655440101' }, // Clinical Psychology
+
+  // "Risks and Benefits: A Systematic Review"
+  { paperId: '880e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440100' }, // Mental Health
+  { paperId: '880e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440300' }, // LLM Evaluation
+  { paperId: '880e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440403' }, // Safety & Risk
+  { paperId: '880e8400-e29b-41d4-a716-446655440102', tagId: '660e8400-e29b-41d4-a716-446655440101' }  // Clinical Psychology
+];
+
+module.exports = { resourcePaperTagLinks };

--- a/server/prisma/seeds/resourcePapers.js
+++ b/server/prisma/seeds/resourcePapers.js
@@ -1,0 +1,130 @@
+/**
+ * Seed data for ResourcePaper table
+ * General research papers on mental health AI (NOT benchmark papers)
+ */
+
+const resourcePapers = [
+  {
+    id: '880e8400-e29b-41d4-a716-446655440100',
+    title: 'Can AI Help in Therapeutic Conversations? Evidence from Large Language Model Applications',
+    authors: [
+      { name: 'Maria Garcia', affiliation: 'Stanford University', order: 1 },
+      { name: 'David Kim', affiliation: 'Stanford University', order: 2 },
+      { name: 'Robert Johnson', affiliation: 'Harvard Medical School', order: 3 }
+    ],
+    publicationDate: new Date('2024-08-20'),
+    publication: 'Nature Medicine',
+    venue: 'Nature Medicine',
+    arxivId: null,
+    doi: '10.1038/s41591-024-example',
+    url: 'https://doi.org/10.1038/s41591-024-example',
+    pdfUrl: null,
+    abstract: 'This study systematically evaluates the therapeutic potential of large language models in mental health conversations. We analyze conversational quality, empathetic responses, and safety considerations across multiple clinical scenarios, finding both promising applications and significant limitations that require human oversight.',
+    imageUrl: null,
+    imageStoragePath: null,
+    citationCount: 312,
+    paperType: 'empirical',
+    isPreprint: false,
+    isPeerReviewed: true,
+    isPublished: true,
+    isFeatured: true,
+    citation: {
+      bibtex: `@article{garcia2024therapeutic,
+  title={Can AI Help in Therapeutic Conversations? Evidence from Large Language Model Applications},
+  author={Garcia, Maria and Kim, David and Johnson, Robert},
+  journal={Nature Medicine},
+  year={2024},
+  doi={10.1038/s41591-024-example}
+}`,
+      apa: 'Garcia, M., Kim, D., & Johnson, R. (2024). Can AI Help in Therapeutic Conversations? Evidence from Large Language Model Applications. Nature Medicine.',
+      mla: 'Garcia, Maria, David Kim, and Robert Johnson. "Can AI Help in Therapeutic Conversations? Evidence from Large Language Model Applications." Nature Medicine (2024).'
+    },
+    metadata: {
+      impactFactor: 82.9,
+      openAccess: false
+    }
+  },
+
+  {
+    id: '880e8400-e29b-41d4-a716-446655440101',
+    title: 'A Framework for Evaluating Empathy in AI-Driven Mental Health Interventions',
+    authors: [
+      { name: 'Jennifer Wu', affiliation: 'MIT', order: 1 },
+      { name: 'Alexander Brown', affiliation: 'MIT', order: 2 }
+    ],
+    publicationDate: new Date('2024-10-05'),
+    publication: 'Proceedings of EMNLP',
+    venue: 'EMNLP 2024',
+    arxivId: '2410.12345',
+    doi: null,
+    url: 'https://arxiv.org/abs/2410.12345',
+    pdfUrl: 'https://arxiv.org/pdf/2410.12345.pdf',
+    abstract: 'We propose a novel framework for evaluating empathetic responses in AI mental health systems. Our approach combines computational linguistics, affective computing, and clinical psychology to assess emotional validation, perspective-taking, and therapeutic rapport, demonstrating superiority over existing evaluation methods.',
+    imageUrl: null,
+    imageStoragePath: null,
+    citationCount: 156,
+    paperType: 'methodology',
+    isPreprint: false,
+    isPeerReviewed: true,
+    isPublished: true,
+    isFeatured: true,
+    citation: {
+      bibtex: `@inproceedings{wu2024empathy,
+  title={A Framework for Evaluating Empathy in AI-Driven Mental Health Interventions},
+  author={Wu, Jennifer and Brown, Alexander},
+  booktitle={Proceedings of EMNLP 2024},
+  year={2024}
+}`,
+      apa: 'Wu, J., & Brown, A. (2024). A Framework for Evaluating Empathy in AI-Driven Mental Health Interventions. Proceedings of EMNLP 2024.',
+      mla: 'Wu, Jennifer, and Alexander Brown. "A Framework for Evaluating Empathy in AI-Driven Mental Health Interventions." Proceedings of EMNLP 2024. 2024.'
+    },
+    metadata: {
+      acceptanceRate: '22.4%',
+      bestPaperNominee: true
+    }
+  },
+
+  {
+    id: '880e8400-e29b-41d4-a716-446655440102',
+    title: 'Risks and Benefits of Large Language Models in Mental Health: A Systematic Review',
+    authors: [
+      { name: 'Sarah Ahmed', affiliation: 'University of Toronto', order: 1 },
+      { name: 'Michael Chen', affiliation: 'University of Toronto', order: 2 },
+      { name: 'Lisa Thompson', affiliation: 'Centre for Addiction and Mental Health', order: 3 }
+    ],
+    publicationDate: new Date('2024-05-12'),
+    publication: 'The Lancet Psychiatry',
+    venue: 'The Lancet Psychiatry',
+    arxivId: null,
+    doi: '10.1016/S2215-0366(24)example',
+    url: 'https://doi.org/10.1016/S2215-0366(24)example',
+    pdfUrl: null,
+    abstract: 'This systematic review examines 147 studies on LLM applications in mental health care. We identify key benefits including improved access and 24/7 availability, alongside critical risks such as hallucinations, privacy concerns, and lack of human connection. We provide evidence-based recommendations for responsible deployment.',
+    imageUrl: null,
+    imageStoragePath: null,
+    citationCount: 523,
+    paperType: 'survey',
+    isPreprint: false,
+    isPeerReviewed: true,
+    isPublished: true,
+    isFeatured: true,
+    citation: {
+      bibtex: `@article{ahmed2024risks,
+  title={Risks and Benefits of Large Language Models in Mental Health: A Systematic Review},
+  author={Ahmed, Sarah and Chen, Michael and Thompson, Lisa},
+  journal={The Lancet Psychiatry},
+  year={2024},
+  doi={10.1016/S2215-0366(24)example}
+}`,
+      apa: 'Ahmed, S., Chen, M., & Thompson, L. (2024). Risks and Benefits of Large Language Models in Mental Health: A Systematic Review. The Lancet Psychiatry.',
+      mla: 'Ahmed, Sarah, Michael Chen, and Lisa Thompson. "Risks and Benefits of Large Language Models in Mental Health: A Systematic Review." The Lancet Psychiatry (2024).'
+    },
+    metadata: {
+      impactFactor: 48.7,
+      studiesReviewed: 147,
+      openAccess: true
+    }
+  }
+];
+
+module.exports = { resourcePapers };

--- a/server/prisma/seeds/resourceTags.js
+++ b/server/prisma/seeds/resourceTags.js
@@ -1,0 +1,304 @@
+/**
+ * Seed data for ResourceTag table
+ * Tags for categorizing benchmarks, articles, and papers
+ */
+
+const resourceTags = [
+  // Domain Tags
+  {
+    id: '660e8400-e29b-41d4-a716-446655440100',
+    name: 'Mental Health',
+    slug: 'mental-health',
+    description: 'General mental health and psychological well-being',
+    category: 'domain',
+    color: '#8B5CF6', // Purple
+    icon: 'brain',
+    sortOrder: 1,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440101',
+    name: 'Clinical Psychology',
+    slug: 'clinical-psychology',
+    description: 'Clinical psychology practice and assessment',
+    category: 'domain',
+    color: '#7C3AED',
+    icon: 'clipboard-check',
+    sortOrder: 2,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440102',
+    name: 'Psychiatry',
+    slug: 'psychiatry',
+    description: 'Medical psychiatry and psychopharmacology',
+    category: 'domain',
+    color: '#6D28D9',
+    icon: 'medical',
+    sortOrder: 3,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440103',
+    name: 'Counseling',
+    slug: 'counseling',
+    description: 'Therapeutic counseling and psychotherapy',
+    category: 'domain',
+    color: '#5B21B6',
+    icon: 'comments',
+    sortOrder: 4,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440104',
+    name: 'General Medicine',
+    slug: 'general-medicine',
+    description: 'Broad medical knowledge and practice',
+    category: 'domain',
+    color: '#DC2626',
+    icon: 'hospital',
+    sortOrder: 5,
+    isActive: true
+  },
+
+  // Condition Tags
+  {
+    id: '660e8400-e29b-41d4-a716-446655440200',
+    name: 'Depression',
+    slug: 'depression',
+    description: 'Major depressive disorder and related conditions',
+    category: 'condition',
+    color: '#3B82F6',
+    icon: 'cloud-rain',
+    sortOrder: 10,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440201',
+    name: 'Anxiety',
+    slug: 'anxiety',
+    description: 'Anxiety disorders and related conditions',
+    category: 'condition',
+    color: '#F59E0B',
+    icon: 'exclamation-circle',
+    sortOrder: 11,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440202',
+    name: 'PTSD',
+    slug: 'ptsd',
+    description: 'Post-traumatic stress disorder',
+    category: 'condition',
+    color: '#EF4444',
+    icon: 'shield-alert',
+    sortOrder: 12,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440203',
+    name: 'Trauma',
+    slug: 'trauma',
+    description: 'Trauma and traumatic experiences',
+    category: 'condition',
+    color: '#DC2626',
+    icon: 'heart-broken',
+    sortOrder: 13,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440204',
+    name: 'OCD',
+    slug: 'ocd',
+    description: 'Obsessive-compulsive disorder',
+    category: 'condition',
+    color: '#7C3AED',
+    icon: 'repeat',
+    sortOrder: 14,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440205',
+    name: 'Bipolar Disorder',
+    slug: 'bipolar-disorder',
+    description: 'Bipolar disorder and mood disorders',
+    category: 'condition',
+    color: '#EC4899',
+    icon: 'chart-line',
+    sortOrder: 15,
+    isActive: true
+  },
+
+  // Method Tags
+  {
+    id: '660e8400-e29b-41d4-a716-446655440300',
+    name: 'LLM Evaluation',
+    slug: 'llm-evaluation',
+    description: 'Evaluation and benchmarking of large language models',
+    category: 'method',
+    color: '#10B981',
+    icon: 'chart-bar',
+    sortOrder: 20,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440301',
+    name: 'Clinical Assessment',
+    slug: 'clinical-assessment',
+    description: 'Clinical diagnostic and assessment tools',
+    category: 'method',
+    color: '#059669',
+    icon: 'stethoscope',
+    sortOrder: 21,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440302',
+    name: 'Expert Evaluation',
+    slug: 'expert-evaluation',
+    description: 'Human expert review and validation',
+    category: 'method',
+    color: '#047857',
+    icon: 'user-check',
+    sortOrder: 22,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440303',
+    name: 'Multimodal',
+    slug: 'multimodal',
+    description: 'Audio, video, and text modalities',
+    category: 'method',
+    color: '#0891B2',
+    icon: 'video',
+    sortOrder: 23,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440304',
+    name: 'Social Media Analysis',
+    slug: 'social-media-analysis',
+    description: 'Analysis of social media data',
+    category: 'method',
+    color: '#0EA5E9',
+    icon: 'hashtag',
+    sortOrder: 24,
+    isActive: true
+  },
+
+  // Application Tags
+  {
+    id: '660e8400-e29b-41d4-a716-446655440400',
+    name: 'Question Answering',
+    slug: 'question-answering',
+    description: 'Mental health question answering tasks',
+    category: 'application',
+    color: '#6366F1',
+    icon: 'question-circle',
+    sortOrder: 30,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440401',
+    name: 'Conversational AI',
+    slug: 'conversational-ai',
+    description: 'Multi-turn dialogue and conversation',
+    category: 'application',
+    color: '#8B5CF6',
+    icon: 'message-circle',
+    sortOrder: 31,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440402',
+    name: 'Detection & Screening',
+    slug: 'detection-screening',
+    description: 'Mental health condition detection and screening',
+    category: 'application',
+    color: '#F59E0B',
+    icon: 'search',
+    sortOrder: 32,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440403',
+    name: 'Safety & Risk',
+    slug: 'safety-risk',
+    description: 'Safety evaluation and risk assessment',
+    category: 'application',
+    color: '#EF4444',
+    icon: 'shield-exclamation',
+    sortOrder: 33,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440404',
+    name: 'Empathy & Understanding',
+    slug: 'empathy-understanding',
+    description: 'Emotional recognition and empathetic response',
+    category: 'application',
+    color: '#EC4899',
+    icon: 'heart',
+    sortOrder: 34,
+    isActive: true
+  },
+
+  // Data Source Tags
+  {
+    id: '660e8400-e29b-41d4-a716-446655440500',
+    name: 'Clinical Trials',
+    slug: 'clinical-trials',
+    description: 'Data from clinical trials and studies',
+    category: 'source',
+    color: '#14B8A6',
+    icon: 'flask',
+    sortOrder: 40,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440501',
+    name: 'Synthetic Data',
+    slug: 'synthetic-data',
+    description: 'LLM-generated or synthetic datasets',
+    category: 'source',
+    color: '#06B6D4',
+    icon: 'cog',
+    sortOrder: 41,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440502',
+    name: 'Reddit',
+    slug: 'reddit',
+    description: 'Data sourced from Reddit',
+    category: 'source',
+    color: '#FF4500',
+    icon: 'reddit',
+    sortOrder: 42,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440503',
+    name: 'PubMed',
+    slug: 'pubmed',
+    description: 'Based on PubMed research abstracts',
+    category: 'source',
+    color: '#2563EB',
+    icon: 'book-medical',
+    sortOrder: 43,
+    isActive: true
+  },
+  {
+    id: '660e8400-e29b-41d4-a716-446655440504',
+    name: 'Standardized Exams',
+    slug: 'standardized-exams',
+    description: 'Professional certification and licensing exams',
+    category: 'source',
+    color: '#7C3AED',
+    icon: 'graduation-cap',
+    sortOrder: 44,
+    isActive: true
+  }
+];
+
+module.exports = { resourceTags };

--- a/server/prisma/seeds/resources.js
+++ b/server/prisma/seeds/resources.js
@@ -1,0 +1,130 @@
+const { resourceBenchmarks } = require('./resourceBenchmarks');
+const { resourceArticles } = require('./resourceArticles');
+const { resourcePapers } = require('./resourcePapers');
+const { resourceTags } = require('./resourceTags');
+const { resourceBenchmarkTagLinks } = require('./resourceBenchmarkTagLinks');
+const { resourceArticleTagLinks } = require('./resourceArticleTagLinks');
+const { resourcePaperTagLinks } = require('./resourcePaperTagLinks');
+
+/**
+ * Seed resources (benchmarks, articles, papers, and tags)
+ */
+async function seedResources(prisma) {
+  console.log('Seeding resource tags...');
+
+  // Create tags first (they're referenced by all resource types)
+  const createdTags = [];
+  for (const tag of resourceTags) {
+    const created = await prisma.resourceTag.upsert({
+      where: { id: tag.id },
+      update: tag,
+      create: tag,
+    });
+    createdTags.push(created);
+  }
+  console.log(`✓ Created ${createdTags.length} resource tags`);
+
+  console.log('Seeding resource benchmarks...');
+
+  // Create benchmarks
+  const createdBenchmarks = [];
+  for (const benchmark of resourceBenchmarks) {
+    const created = await prisma.resourceBenchmark.upsert({
+      where: { id: benchmark.id },
+      update: benchmark,
+      create: benchmark,
+    });
+    createdBenchmarks.push(created);
+  }
+  console.log(`✓ Created ${createdBenchmarks.length} resource benchmarks`);
+
+  console.log('Seeding resource articles...');
+
+  // Create articles
+  const createdArticles = [];
+  for (const article of resourceArticles) {
+    const created = await prisma.resourceArticle.upsert({
+      where: { id: article.id },
+      update: article,
+      create: article,
+    });
+    createdArticles.push(created);
+  }
+  console.log(`✓ Created ${createdArticles.length} resource articles`);
+
+  console.log('Seeding resource papers...');
+
+  // Create papers
+  const createdPapers = [];
+  for (const paper of resourcePapers) {
+    const created = await prisma.resourcePaper.upsert({
+      where: { id: paper.id },
+      update: paper,
+      create: paper,
+    });
+    createdPapers.push(created);
+  }
+  console.log(`✓ Created ${createdPapers.length} resource papers`);
+
+  console.log('Seeding resource tag links...');
+
+  // Create benchmark-tag links
+  let benchmarkLinkCount = 0;
+  for (const link of resourceBenchmarkTagLinks) {
+    await prisma.resourceBenchmarkTagLink.upsert({
+      where: {
+        benchmarkId_tagId: {
+          benchmarkId: link.benchmarkId,
+          tagId: link.tagId,
+        },
+      },
+      update: {},
+      create: link,
+    });
+    benchmarkLinkCount++;
+  }
+  console.log(`✓ Created ${benchmarkLinkCount} benchmark-tag links`);
+
+  // Create article-tag links
+  let articleLinkCount = 0;
+  for (const link of resourceArticleTagLinks) {
+    await prisma.resourceArticleTagLink.upsert({
+      where: {
+        articleId_tagId: {
+          articleId: link.articleId,
+          tagId: link.tagId,
+        },
+      },
+      update: {},
+      create: link,
+    });
+    articleLinkCount++;
+  }
+  console.log(`✓ Created ${articleLinkCount} article-tag links`);
+
+  // Create paper-tag links
+  let paperLinkCount = 0;
+  for (const link of resourcePaperTagLinks) {
+    await prisma.resourcePaperTagLink.upsert({
+      where: {
+        paperId_tagId: {
+          paperId: link.paperId,
+          tagId: link.tagId,
+        },
+      },
+      update: {},
+      create: link,
+    });
+    paperLinkCount++;
+  }
+  console.log(`✓ Created ${paperLinkCount} paper-tag links`);
+
+  return {
+    tags: createdTags,
+    benchmarks: createdBenchmarks,
+    articles: createdArticles,
+    papers: createdPapers,
+  };
+}
+
+module.exports = seedResources;


### PR DESCRIPTION
### Summary 
Implements database schema for Resources page to showcase external mental health benchmarks, research papers, and news articles.

### Changes
**Resources Schema** (`/server/prisma/schema/resources.prisma`)
  - Added `BenchmarkType` enum and 7 new models (ResourceBenchmark, ResourceArticle, ResourcePaper, ResourceTag + 3
  link tables)
  - Dual image support: external URLs (MVP) + local storage path (future)
  - Seed data: 10 benchmarks, 4 articles, 3 papers, 30 tags with associations
  - User relations for audit trails

  **Community Schema Improvements** (`/server/prisma/schema/community.prisma`)
  - Added enums: `UpdateCategory`, `SuggestionStatus`, `SuggestionCategory`
  - **Update model**: Type-safe categories, featured flag, scheduled publishing, URL slugs
  - **Suggestion model**: Lifecycle tracking (reviewed, implemented, closed), priority ranking, GitHub issue links
  - **TeamMember model**: Start/end dates for tenure tracking, social links, expertise areas
  - **UpdateReaction model**: Added `updatedAt` for reaction 